### PR TITLE
Improve the documentation, pull in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpentelemetryHoneycombSampler
 
+<!-- MDOC !-->
+
 Sample with Honeycomb!
 
 This package provides a handy interface for sampling which is similar to how stock otel samplers work, but with all the messy details abstracted away. Simply pattern match on spans and set a sample rate.
@@ -72,11 +74,9 @@ Honeycomb's sample rates are expressed as a positive integer N (1, 2, 3, 1000, e
 
 A sample rate of 1, therefore, results in all of your events being sent to Honeycomb. This is as if you did not configure sampling at all.
 
-
 ## Installation
 
 The package can be installed by adding `opentelemetry_honeycomb_sampler` to your list of dependencies in `mix.exs`:
-
 
 The docs can be found at <https://hexdocs.pm/opentelemetry_honeycomb_sampler>.
 

--- a/lib/opentelemetry_honeycomb_sampler.ex
+++ b/lib/opentelemetry_honeycomb_sampler.ex
@@ -1,7 +1,9 @@
 defmodule OpentelemetryHoneycombSampler do
-  @moduledoc """
-  Honeycomb Sampler for OpenTelemetry.
-  """
+  @external_resource "README.md"
+  @moduledoc @external_resource
+             |> File.read!()
+             |> String.split("<!-- MDOC !-->")
+             |> Enum.fetch!(1)
 
   @callback setup(:otel_sampler.sampler_opts()) :: :otel_sampler.sampler_config()
   @callback description(:otel_sampler.sampler_config()) :: :otel_sampler.description()


### PR DESCRIPTION
This makes the docs a bit nicer, pulling in all the great information in the README

<img width="1920" alt="Screenshot 2023-10-13 at 1 17 42 PM" src="https://github.com/derekkraan/opentelemetry_honeycomb_sampler/assets/1019721/f5ec79a3-6b73-4883-9b05-bdc7c040afdd">
